### PR TITLE
Deploy webapp via ArgoCD

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - main
-      - dockerfile
-      - cd
+      
     tags:
       - "*"
   workflow_dispatch:

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dockerfile
+      - cd
     tags:
       - "*"
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ cython_debug/
 
 # Excel files
 *.xlsx
+supervisord.pid

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,5 @@ RUN pip install supervisor
 EXPOSE 8501 5000
 
 ENV PYTHONPATH=src/
-CMD ["uv", "run", "uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "5000"]
+
+CMD ["supervisord", "-c", "supervisord.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,5 @@ EXPOSE 8501 5000
 
 ENV PYTHONPATH=src/
 # CMD ["uv", "run", "uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "5000"]
-CMD ["uv", "run", "streamlit", "run", "app/main.py"]
-# CMD ["supervisord", "-c", "supervisord.conf"]
+# CMD ["uv", "run", "streamlit", "run", "app/main.py"]
+CMD ["supervisord", "-c", "supervisord.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,5 @@ RUN pip install supervisor
 EXPOSE 8501 5000
 
 ENV PYTHONPATH=src/
-# CMD ["uv", "run", "uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "5000"]
-# CMD ["uv", "run", "streamlit", "run", "app/main.py"]
+
 CMD ["supervisord", "-c", "supervisord.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,12 @@ RUN uv sync
 # Copy the rest of the code
 COPY . .
 
+RUN pip install supervisor
+
 # Copy supervisord config
 COPY supervisord.conf /etc/supervisord.conf
 
 # Expose ports: 8501 for Streamlit, 5000 for FastAPI
 EXPOSE 8501 5000
 
-CMD ["/usr/local/bin/supervisord", "-c", "/etc/supervisord.conf"]
+CMD ["supervisord", "-c", "/etc/supervisord.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,7 @@ COPY . .
 
 RUN pip install supervisor
 
-# Copy supervisord config
-COPY supervisord.conf /etc/supervisord.conf
-
 # Expose ports: 8501 for Streamlit, 5000 for FastAPI
 EXPOSE 8501 5000
 
-CMD ["supervisord", "-c", "/etc/supervisord.conf"]
+CMD ["supervisord", "-c", "supervisord.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,5 @@ RUN pip install supervisor
 # Expose ports: 8501 for Streamlit, 5000 for FastAPI
 EXPOSE 8501 5000
 
+ENV PYTHONPATH=src/
 CMD ["uv", "run", "uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ RUN pip install supervisor
 # Expose ports: 8501 for Streamlit, 5000 for FastAPI
 EXPOSE 8501 5000
 
-CMD ["supervisord", "-c", "supervisord.conf"]
+CMD ["uv", "run", "uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,6 @@ RUN pip install supervisor
 EXPOSE 8501 5000
 
 ENV PYTHONPATH=src/
-
-CMD ["supervisord", "-c", "supervisord.conf"]
+# CMD ["uv", "run", "uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "5000"]
+CMD ["uv", "run", "streamlit", "run", "app/main.py"]
+# CMD ["supervisord", "-c", "supervisord.conf"]

--- a/deployment/argocd-templates/web-app-graph-rag.yaml
+++ b/deployment/argocd-templates/web-app-graph-rag.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: codif-ape-graph-rag-webapp
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/InseeFrLab/codif-ape-graph-rag.git
+    targetRevision: main
+    path: deployment
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: projet-ape
+  syncPolicy:
+    automated:
+      selfHeal: true

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: codif-ape-graph-rag-api
-          image: meilametayebjee/codification-ape-graph-rag-api:main
+          image: meilametayebjee/codification-ape-graph-rag-api:cd
           imagePullPolicy: Always
           env:
             - name: AWS_ACCESS_KEY_ID

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -32,6 +32,11 @@ spec:
               value: us-east-1
             - name: AUTH_API
               value: "False"
+            - name: NEO4J_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: neo4j
+                  key: NEO_4J_API_KEY
           resources:
             limits:
               cpu: 30000m

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -36,7 +36,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: neo4j
-                  key: NEO_4J_API_KEY
+                  key: apiKey
           resources:
             limits:
               cpu: 30000m

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -1,0 +1,41 @@
+# Creating MLflow deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: codif-ape-graph-rag-api-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: codif-ape-graph-rag-api-deployment
+  template:
+    metadata:
+      labels:
+        app: codif-ape-graph-rag-api-deployment
+    spec:
+      containers:
+        - name: codif-ape-graph-rag-api
+          image: meilametayebjee/codification-ape-graph-rag-api:main
+          imagePullPolicy: Always
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: my-s3-creds
+                  key: accessKey
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: my-s3-creds
+                  key: secretKey
+            - name: AWS_DEFAULT_REGION
+              value: us-east-1
+            - name: AUTH_API
+              value: "False"
+          resources:
+            limits:
+              cpu: 30000m
+              memory: 50Gi
+            requests:
+              cpu: 100m
+              memory: 2Gi

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: codif-ape-graph-rag-streamlit-deployment
+  name: codif-ape-graph-rag-streamlit
 spec:
   replicas: 1
   selector:

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -1,22 +1,23 @@
-# Creating MLflow deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: codif-ape-graph-rag-api-deployment
+  name: codif-ape-graph-rag-streamlit-deployment
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: codif-ape-graph-rag-api-deployment
+      app: codif-ape-graph-rag-streamlit
   template:
     metadata:
       labels:
-        app: codif-ape-graph-rag-api-deployment
+        app: codif-ape-graph-rag-streamlit
     spec:
       containers:
-        - name: codif-ape-graph-rag-api
+        - name: streamlit
           image: meilametayebjee/codification-ape-graph-rag-api:cd
           imagePullPolicy: Always
+          ports:
+            - containerPort: 8501
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
@@ -30,8 +31,6 @@ spec:
                   key: secretKey
             - name: AWS_DEFAULT_REGION
               value: us-east-1
-            - name: AUTH_API
-              value: "False"
             - name: NEO4J_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -39,8 +38,8 @@ spec:
                   key: apiKey
           resources:
             limits:
-              cpu: 30000m
-              memory: 50Gi
+              cpu: "1000m"
+              memory: "2Gi"
             requests:
-              cpu: 100m
-              memory: 2Gi
+              cpu: "100m"
+              memory: "512Mi"

--- a/deployment/ingress.yaml
+++ b/deployment/ingress.yaml
@@ -1,10 +1,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: codif-ape-graph-rag-api-ingress
+  name: codif-ape-graph-rag-streamlit-ingress
   annotations:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "360"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "360"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
   tls:
     - hosts:
@@ -13,10 +14,10 @@ spec:
     - host: codification-ape-graph-rag.lab.sspcloud.fr
       http:
         paths:
-          - path: /
+          - path: /(.*)
             pathType: Prefix
             backend:
               service:
-                name: codif-ape-graph-rag-api-service
+                name: codif-ape-graph-rag-streamlit-service
                 port:
-                  number: 80
+                  number: 8501

--- a/deployment/ingress.yaml
+++ b/deployment/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "360"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "360"
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
   tls:
     - hosts:
@@ -14,7 +13,7 @@ spec:
     - host: codification-ape-graph-rag.lab.sspcloud.fr
       http:
         paths:
-          - path: /(.*)
+          - path: /
             pathType: Prefix
             backend:
               service:

--- a/deployment/ingress.yaml
+++ b/deployment/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: codif-ape-graph-rag-api-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "360"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "360"
+spec:
+  tls:
+    - hosts:
+        - codification-ape-graph-rag.lab.sspcloud.fr
+  rules:
+    - host: codification-ape-graph-rag.lab.sspcloud.fr
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: codif-ape-graph-rag-api-service
+                port:
+                  number: 80

--- a/deployment/service.yaml
+++ b/deployment/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: codif-ape-graph-rag-api-service
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    app: codif-ape-graph-rag-api-deployment

--- a/deployment/service.yaml
+++ b/deployment/service.yaml
@@ -3,9 +3,11 @@ kind: Service
 metadata:
   name: codif-ape-graph-rag-streamlit-service
 spec:
+  type: ClusterIP
+  ports:
+    - port: 8501
+      targetPort: 8501
+      protocol: TCP
+      name: http
   selector:
     app: codif-ape-graph-rag-streamlit
-  ports:
-    - protocol: TCP
-      port: 8501
-      targetPort: 8501

--- a/deployment/service.yaml
+++ b/deployment/service.yaml
@@ -1,13 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: codif-ape-graph-rag-api-service
+  name: codif-ape-graph-rag-streamlit-service
 spec:
-  type: ClusterIP
-  ports:
-    - port: 80
-      targetPort: 80
-      protocol: TCP
-      name: http
   selector:
-    app: codif-ape-graph-rag-api-deployment
+    app: codif-ape-graph-rag-streamlit
+  ports:
+    - protocol: TCP
+      port: 8501
+      targetPort: 8501

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "fastapi>=0.115.12",
     "streamlit>=1.44.0",
     "langchain-openai>=0.3.11",
-    "supervisor>=4.2.5",
 ]
 authors = [
   {name="Thomas Faria", email="thomas.faria@insee.fr"}

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -6,13 +6,13 @@ command=uv run streamlit run app/main.py
 directory=/home/onyxia/work/codif-ape-graph-rag
 autostart=true
 autorestart=true
-stdout_logfile=/tmp/streamlit.log
-stderr_logfile=/tmp/streamlit.err.log
+stdout_logfile=streamlit.log
+stderr_logfile=streamlit.err.log
 
 [program:fastapi]
 command=uv run uvicorn src.api.main:app --host 0.0.0.0 --port 5000
 directory=/home/onyxia/work/codif-ape-graph-rag
 autostart=true
 autorestart=true
-stdout_logfile=/tmp/fastapi.log
-stderr_logfile=/tmp/fastapi.err.log
+stdout_logfile=fastapi.log
+stderr_logfile=fastapi.err.log

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -8,7 +8,6 @@ autostart=true
 autorestart=true
 stdout_logfile=/tmp/streamlit.log
 stderr_logfile=/tmp/streamlit.err.log
-environment=PYTHONPATH="/home/onyxia/work/codif-ape-graph-rag/src"
 
 [program:fastapi]
 command=uv run uvicorn src.api.main:app --host 0.0.0.0 --port 5000
@@ -17,4 +16,3 @@ autostart=true
 autorestart=true
 stdout_logfile=/tmp/fastapi.log
 stderr_logfile=/tmp/fastapi.err.log
-environment=PYTHONPATH="/home/onyxia/work/codif-ape-graph-rag/src"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,17 +2,19 @@
 nodaemon=true
 
 [program:streamlit]
-command=uv run streamlit run app/main.py
-directory=/app
+command=streamlit run app/main.py
+directory=/home/onyxia/work/codif-ape-graph-rag
 autostart=true
 autorestart=true
-stdout_logfile=/dev/stdout
-stderr_logfile=/dev/stderr
+stdout_logfile=/tmp/streamlit.log
+stderr_logfile=/tmp/streamlit.err.log
+environment=PYTHONPATH="/home/onyxia/work/codif-ape-graph-rag/src"
 
 [program:fastapi]
 command=uv run uvicorn src.api.main:app --host 0.0.0.0 --port 5000
-directory=/app
+directory=/home/onyxia/work/codif-ape-graph-rag
 autostart=true
 autorestart=true
-stdout_logfile=/dev/stdout
-stderr_logfile=/dev/stderr
+stdout_logfile=/tmp/fastapi.log
+stderr_logfile=/tmp/fastapi.err.log
+environment=PYTHONPATH="/home/onyxia/work/codif-ape-graph-rag/src"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:streamlit]
-command=streamlit run app/main.py
+command=uv run streamlit run app/main.py
 directory=/home/onyxia/work/codif-ape-graph-rag
 autostart=true
 autorestart=true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -6,14 +6,14 @@ command=uv run streamlit run app/main.py
 directory=/home/onyxia/work/codif-ape-graph-rag
 autostart=true
 autorestart=true
-stdout_logfile=logs/streamlit.log
-stderr_logfile=logs/streamlit.err.log
+stdout_logfile=streamlit.log
+stderr_logfile=streamlit.err.log
 
 [program:fastapi]
 command=uv run uvicorn src.api.main:app --host 0.0.0.0 --port 5000
 directory=/home/onyxia/work/codif-ape-graph-rag
 autostart=true
 autorestart=true
-stdout_logfile=logs/fastapi.log
-stderr_logfile=logs/fastapi.err.log
+stdout_logfile=fastapi.log
+stderr_logfile=fastapi.err.log
 environment=PYTHONPATH="src/"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 
 [program:streamlit]
 command=uv run streamlit run app/main.py
-directory=/home/onyxia/work/codif-ape-graph-rag
+directory=codif-ape-graph-rag
 autostart=true
 autorestart=true
 stdout_logfile=streamlit.log
@@ -11,7 +11,7 @@ stderr_logfile=streamlit.err.log
 
 [program:fastapi]
 command=uv run uvicorn src.api.main:app --host 0.0.0.0 --port 5000
-directory=/home/onyxia/work/codif-ape-graph-rag
+directory=codif-ape-graph-rag
 autostart=true
 autorestart=true
 stdout_logfile=fastapi.log

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,6 @@ nodaemon=true
 
 [program:streamlit]
 command=uv run streamlit run app/main.py
-directory=codif-ape-graph-rag
 autostart=true
 autorestart=true
 stdout_logfile=streamlit.log
@@ -11,7 +10,6 @@ stderr_logfile=streamlit.err.log
 
 [program:fastapi]
 command=uv run uvicorn src.api.main:app --host 0.0.0.0 --port 5000
-directory=codif-ape-graph-rag
 autostart=true
 autorestart=true
 stdout_logfile=fastapi.log

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -6,13 +6,14 @@ command=uv run streamlit run app/main.py
 directory=/home/onyxia/work/codif-ape-graph-rag
 autostart=true
 autorestart=true
-stdout_logfile=streamlit.log
-stderr_logfile=streamlit.err.log
+stdout_logfile=logs/streamlit.log
+stderr_logfile=logs/streamlit.err.log
 
 [program:fastapi]
 command=uv run uvicorn src.api.main:app --host 0.0.0.0 --port 5000
 directory=/home/onyxia/work/codif-ape-graph-rag
 autostart=true
 autorestart=true
-stdout_logfile=fastapi.log
-stderr_logfile=fastapi.err.log
+stdout_logfile=logs/fastapi.log
+stderr_logfile=logs/fastapi.err.log
+environment=PYTHONPATH="src/"

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,6 @@ dependencies = [
     { name = "pyarrow" },
     { name = "s3fs" },
     { name = "streamlit" },
-    { name = "supervisor" },
     { name = "uvicorn" },
 ]
 
@@ -318,7 +317,6 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=19.0.1" },
     { name = "s3fs", specifier = ">=2024.12.0" },
     { name = "streamlit", specifier = ">=1.44.0" },
-    { name = "supervisor", specifier = ">=4.2.5" },
     { name = "uvicorn", specifier = ">=0.34.0" },
 ]
 
@@ -1567,15 +1565,6 @@ wheels = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "78.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/0db4da3bc908df06e5efae42b44e75c81dd52716e10192ff36d0c1c8e379/setuptools-78.1.0.tar.gz", hash = "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54", size = 1367827 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/21/f43f0a1fa8b06b32812e0975981f4677d28e0f3271601dc88ac5a5b83220/setuptools-78.1.0-py3-none-any.whl", hash = "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8", size = 1256108 },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1670,18 +1659,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b4/86/764e2079c58790f232bb5882853fe8a68302dfdd0e29a5cf6efeb3bbcd17/streamlit-1.44.0.tar.gz", hash = "sha256:da75933bae94595167f43822dea43fcdde0d747433f7d04989266d78967951bb", size = 9422437 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/9e/e51e34f504940da00145795b9e8be9c129704708b071f672f3626a37d842/streamlit-1.44.0-py3-none-any.whl", hash = "sha256:98510d03e53622bba8f0e9f2fd4f1191b3b55e5c7e55abbbaa0289cb9e21cdea", size = 9812034 },
-]
-
-[[package]]
-name = "supervisor"
-version = "4.2.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/37/517989b05849dd6eaa76c148f24517544704895830a50289cbbf53c7efb9/supervisor-4.2.5.tar.gz", hash = "sha256:34761bae1a23c58192281a5115fb07fbf22c9b0133c08166beffc70fed3ebc12", size = 466073 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/7a/0ad3973941590c040475046fef37a2b08a76691e61aa59540828ee235a6e/supervisor-4.2.5-py2.py3-none-any.whl", hash = "sha256:2ecaede32fc25af814696374b79e42644ecaba5c09494c51016ffda9602d0f08", size = 319561 },
 ]
 
 [[package]]


### PR DESCRIPTION
- handling neo4j secrets via Kubernetes secrets
- "double" deployment API + webapp using supervisord : only the streamlit app is exposed, the API is running in the container
- deployment / service / ingress YAMLs, as well as argo CD template