### PR TITLE
Simulatenous deployment of API and Streamlit

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - argo-double-deployment
       
     tags:
       - "*"

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - argo-double-deployment
       
     tags:
       - "*"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # codif-ape-graph-rag
 
-You need to install to first install [`uv`](https://github.com/astral-sh/uv), using for instance `pip install uv` if applicable.
 
-Then run the following commands:
+## Local run 🏛️ 
+You need to install to first install [**uv**](https://github.com/astral-sh/uv), using for instance `pip install uv` if applicable.
+
+Please reach out to us to get our [**Neo4J**](https://neo4j.com/) graph database's password. Then run the following commands to locally launch the API:
 
 ```bash
 cd src
@@ -10,3 +12,22 @@ cd src
 export NEO4J_API_KEY= [NEO4J PASSWORD]
 uvicorn api.main:app --reload --host 0.0.0.0 --port 5000
 ```
+
+To locally launch the web application, run the following command, on another terminal and from the root path of the repo:
+
+```bash
+uv run streamlit run app/main.py
+```
+
+## Deployment 🚀
+
+The web application is available [here](https://codification-ape-graph-rag.lab.sspcloud.fr/), and the API swagger [there](https://codification-ape-graph-rag.lab.sspcloud.fr/api/docs).
+
+We used:
+- [**supervisord**](https://supervisord.org/) for double deployment of the API and the web application, on two different custom ports 🖇️
+- **Docker** for conteneurization 🐳 (find the image repo [here](https://hub.docker.com/repository/docker/meilametayebjee/codification-ape-graph-rag-api/general))
+- **GitHub Actions** for continous integration ♾️
+- and **ArgoCD** for continous deployment 🚀
+
+We used our [datalab](https://datalab.sspcloud.fr/) powered by [**Onyxia**](https://www.onyxia.sh/) and a **Kubernetes** cluster to deploy the application.
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 import httpx
 import streamlit as st
 
-API_BASE_URL = "http://localhost:5000"  # or wherever your FastAPI is running
+API_BASE_URL = "http://localhost:5000/api"  # or wherever your FastAPI is running
 
 st.set_page_config(page_title="Codif APE Classifier", layout="centered")
 

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -16,9 +16,9 @@ spec:
         - name: streamlit
           image: meilametayebjee/codification-ape-graph-rag-api:latest
           imagePullPolicy: Always
-          ports:
+5000          ports:
             - containerPort: 8501
-            - containerPort: 5000
+            - containerPort: 
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: streamlit
-          image: meilametayebjee/codification-ape-graph-rag-api:argo-double-deployment
+          image: meilametayebjee/codification-ape-graph-rag-api:main
           imagePullPolicy: Always
           ports:
             - containerPort: 8501

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -16,9 +16,9 @@ spec:
         - name: streamlit
           image: meilametayebjee/codification-ape-graph-rag-api:latest
           imagePullPolicy: Always
-5000          ports:
+          ports:
             - containerPort: 8501
-            - containerPort: 
+            - containerPort: 5000
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -1,23 +1,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: codif-ape-graph-rag-streamlit
+  name: codif-ape-graph-rag
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: codif-ape-graph-rag-streamlit
+      app: codif-ape-graph-rag
   template:
     metadata:
       labels:
-        app: codif-ape-graph-rag-streamlit
+        app: codif-ape-graph-rag
     spec:
       containers:
         - name: streamlit
-          image: meilametayebjee/codification-ape-graph-rag-api:cd
+          image: meilametayebjee/codification-ape-graph-rag-api:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8501
+            - containerPort: 5000
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: streamlit
-          image: meilametayebjee/codification-ape-graph-rag-api:latest
+          image: meilametayebjee/codification-ape-graph-rag-api:argo-double-deployment
           imagePullPolicy: Always
           ports:
             - containerPort: 8501

--- a/deployment/ingress.yaml
+++ b/deployment/ingress.yaml
@@ -13,7 +13,7 @@ spec:
     - host: codification-ape-graph-rag.lab.sspcloud.fr
       http:
         paths:
-          - path: /api/
+          - path: /api
             pathType: Prefix
             backend:
               service:

--- a/deployment/ingress.yaml
+++ b/deployment/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: codif-ape-graph-rag-streamlit-ingress
+  name: codif-ape-graph-rag-ingress
   annotations:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "360"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "360"
@@ -13,6 +13,13 @@ spec:
     - host: codification-ape-graph-rag.lab.sspcloud.fr
       http:
         paths:
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: codif-ape-graph-rag-fastapi-service
+                port:
+                  number: 5000
           - path: /
             pathType: Prefix
             backend:

--- a/deployment/service-api.yaml
+++ b/deployment/service-api.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: codif-ape-graph-rag-fastapi-service
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5000
+      targetPort: 500
+      protocol: TCP
+      name: http
+  selector:
+    app: codif-ape-graph-rag

--- a/deployment/service-api.yaml
+++ b/deployment/service-api.yaml
@@ -6,7 +6,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 5000
-      targetPort: 500
+      targetPort: 5000
       protocol: TCP
       name: http
   selector:

--- a/deployment/service-webapp.yaml
+++ b/deployment/service-webapp.yaml
@@ -10,4 +10,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: codif-ape-graph-rag-streamlit
+    app: codif-ape-graph-rag

--- a/setup.sh
+++ b/setup.sh
@@ -2,5 +2,3 @@
 
 uv sync
 uv run pre-commit install
-
-export NEO4J_API_KEY=***

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -23,7 +23,7 @@ async def lifespan(app: FastAPI):
     logger.info("🛑 Shutting down API lifespan")
 
 
-app = FastAPI(title="Codif APE Classifier API", version="1.0.0", lifespan=lifespan)
+app = FastAPI(title="Codif APE Classifier API", version="1.0.0", lifespan=lifespan, root_path="/api")
 
 routers = [flat_rag.router, hierarchical_rag.router, flat_embeddings.router, hierarchical_embeddings.router]
 


### PR DESCRIPTION
Previous PR #8 only "ingressed" the webapp.

We keep the same supervisord structure, but also ingress the api port to be able to have access to it (with two services, but a single ingress).

The ingress URL is the same, with `api/` prefix added (`FastAPI` 's `root_path` has been updated accordingly, as well as `API_BASE_URL` for the streamlit app).